### PR TITLE
Updating tooling, add --version

### DIFF
--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "doc",
       "dependencies": {
-        "@node-core/api-docs-tooling": "github:nodejs/api-docs-tooling#91df7496b67426b5b0f8cb6ded7a844a8f48afd1"
+        "@node-core/api-docs-tooling": "github:nodejs/api-docs-tooling#222fea362e70641c443b51e7094cf78df2a2f16b"
       }
     },
     "node_modules/@actions/core": {
@@ -43,6 +43,27 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "license": "MIT"
+    },
+    "node_modules/@clack/core": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.4.2.tgz",
+      "integrity": "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.10.1.tgz",
+      "integrity": "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.4.2",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
@@ -138,10 +159,11 @@
       }
     },
     "node_modules/@node-core/api-docs-tooling": {
-      "resolved": "git+ssh://git@github.com/nodejs/api-docs-tooling.git#91df7496b67426b5b0f8cb6ded7a844a8f48afd1",
-      "integrity": "sha512-Wbz6CwLiC7ruPza0EyworjKIfj1ZiNRqxFDV0bV2u1fg3m23r6eQEwRNkdRcg0KU2P+zDqSDQuB/GuauB/JdxQ==",
+      "resolved": "git+ssh://git@github.com/nodejs/api-docs-tooling.git#222fea362e70641c443b51e7094cf78df2a2f16b",
+      "integrity": "sha512-x+K4H1BnQgcO7ic48jTERpC9FjUF4WVKdg9Gxg/Nd/K070Rha+2VvuaBaLm8QIzZj+hjiZGxylsU1DBzx1JHmA==",
       "dependencies": {
         "@actions/core": "^1.11.1",
+        "@clack/prompts": "^0.10.1",
         "@orama/orama": "^3.1.3",
         "@orama/plugin-data-persistence": "^3.1.3",
         "acorn": "^8.14.1",
@@ -175,22 +197,22 @@
       }
     },
     "node_modules/@orama/orama": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.5.tgz",
-      "integrity": "sha512-iAy2H6VWbS/fFLkbioGec5g3uDNj65+wpADL8k1RbxEGoquIPl3xqYMKux30dJV97Rr1OnXgC0kCLWRQi/Mrdg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.6.tgz",
+      "integrity": "sha512-qtSrqCqRU93SjEBedz987tvWao1YQSELjBhGkHYGVP7Dg0lBWP6d+uZEIt5gxTAYio/YWWlhivmRABvRfPLmnQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 16.0.0"
       }
     },
     "node_modules/@orama/plugin-data-persistence": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@orama/plugin-data-persistence/-/plugin-data-persistence-3.1.5.tgz",
-      "integrity": "sha512-twt3F9F2HTWQJBj7omERIe5uQO2cNhbWG2dN3kND/fPCKM338k00LNC0aln8oSUecbVRi5BAh2MN9N5+mt9ZBQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@orama/plugin-data-persistence/-/plugin-data-persistence-3.1.6.tgz",
+      "integrity": "sha512-6he5bwPZUzC7D7WSaLg3kdIRjk/DsedpnJQDPuiDBL+TYBD9heBVZx19C9aypys7vojFj+3t0brHhccoM0vReA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@msgpack/msgpack": "^2.7.2",
-        "@orama/orama": "3.1.5",
+        "@orama/orama": "3.1.6",
         "dpack": "^0.6.22"
       }
     },
@@ -508,9 +530,9 @@
       }
     },
     "node_modules/css-selector-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.1.tgz",
-      "integrity": "sha512-Y+DuvJ7JAjpL1f4DeILe5sXCC3kRXMl0DxM4lAWbS8/jEZ29o3V0L5TL6zIifj4Csmj6c+jiF2ENjida2OVOGA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-WfUcL99xWDs7b3eZPoRszWVfbNo8ErCF15PTvVROjkShGlAfjIkG6hlfj/sl6/rfo5Q9x9ryJ3VqVnAZDA+gcw==",
       "funding": [
         {
           "type": "github",
@@ -1737,19 +1759,19 @@
       }
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.5.4.tgz",
-      "integrity": "sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.11.2.tgz",
+      "integrity": "sha512-F7Ld4oDZJCI5/wCZ8AOffQbqjSzIRpKH7I/iuSs1SkhZeCj0wS6PMZ4W6VA16TWHrAo0Y9bBKEJOe7tvwcTXnw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.1.0.tgz",
-      "integrity": "sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.2.0.tgz",
+      "integrity": "sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
-        "oniguruma-parser": "^0.5.4",
+        "oniguruma-parser": "^0.11.0",
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
       }
@@ -1804,6 +1826,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/property-information": {
       "version": "7.0.0",
@@ -1989,6 +2017,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc",
   "dependencies": {
-    "@node-core/api-docs-tooling": "github:nodejs/api-docs-tooling#91df7496b67426b5b0f8cb6ded7a844a8f48afd1"
+    "@node-core/api-docs-tooling": "github:nodejs/api-docs-tooling#222fea362e70641c443b51e7094cf78df2a2f16b"
   }
 }

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -605,7 +605,15 @@ if not exist %node_exe% (
 mkdir %config%\doc
 robocopy /e doc\api %config%\doc\api
 
-"%npx_exe%" --prefix tools/doc api-docs-tooling -t legacy-html-all legacy-json-all api-links -i doc/api/*.md -i lib/*.js -o out/doc/api/ --lint-dry-run -c file://%~dp0\CHANGELOG.md
+%npx_exe% ^
+  --prefix tools/doc api-docs-tooling generate ^
+  -t legacy-html-all legacy-json-all api-links ^
+  -i doc/api/*.md ^
+  -i lib/*.js ^
+  -o out/doc/api/ ^
+  --no-lint ^
+  -c file://%~dp0\CHANGELOG.md ^
+  -v %NODE_VERSION%
 
 :run
 @rem Run tests if requested.
@@ -621,7 +629,7 @@ for /d %%F in (test\addons\??_*) do (
   rd /s /q %%F
 )
 :: generate
-"%npx_exe%" --prefix tools/doc api-docs-tooling -t addon-verify -i "%~dp0doc\api\addons.md" -o "%~dp0test\addons"
+"%npx_exe%" --prefix tools/doc api-docs-tooling generate -t addon-verify -i "%~dp0doc\api\addons.md" -o "%~dp0test\addons" --no-lint
 if %errorlevel% neq 0 exit /b %errorlevel%
 :: building addons
 setlocal
@@ -764,7 +772,7 @@ for /D %%D IN (doc\*) do (
   )
 )
 %node_exe% tools\lint-md\lint-md.mjs %lint_md_files%
-%npx_exe% --prefix tools\doc api-docs-tooling -i doc\api\*.md
+%npx_exe% --prefix tools\doc api-docs-tooling lint -i doc\api\*.md
 ENDLOCAL
 goto format-md
 


### PR DESCRIPTION
> It pretends it generates the docs for Node.js 22.14.0 instead of 24.0.0 🤨

Resolves that, + updates the tooling to use the CLI subcommands. Hope this helps :-)